### PR TITLE
Fix switching workspaces with empty middle workspace

### DIFF
--- a/dynamic_workspaces.py
+++ b/dynamic_workspaces.py
@@ -27,6 +27,7 @@ class DynamicWorkspaces:
         self.window_classrole_blacklist = [
             "tilix.quake"
         ]
+        self.last = 0
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         self.screen = Wnck.Screen.get_default()
         self.popup = Notify.Notification.new("")
@@ -98,6 +99,11 @@ class DynamicWorkspaces:
                     if workspace_empty:
                         if not (workspace == self.screen.get_workspaces()[-1]):
                             self.remove_workspace_by_index(i)
+        # Update last workspace
+        try:
+            self.last = self.screen.get_active_workspace().get_number()
+        except AttributeError:
+            pass
 
     # Removes blacklisted windows from the list of visible windows
     def remove_blacklist(self, windows):
@@ -131,6 +137,12 @@ class DynamicWorkspaces:
 
     # Removes a workspace by index using wmctrl
     def remove_workspace_by_index(self, index):
+        # Get curent workspace number
+        workspace_num = None
+        try:
+            workspace_num = self.screen.get_active_workspace().get_number()
+        except AttributeError:
+            pass
         # Get current workspaces using wmctrl
         workspaces = subprocess.check_output("wmctrl -d", shell=True).decode("utf-8").splitlines()
         # Get current windows and their workspaces
@@ -142,7 +154,10 @@ class DynamicWorkspaces:
             # Move the windows that are left one workspace to the left
             window.move_to_workspace(self.screen.get_workspaces()[window.get_workspace().get_number() - 1])
         self.pop_workspace(len(workspaces))
-        os.popen(f"wmctrl -s {index}")
+        # Make sure you stay on the workspace
+        if workspace_num != None:
+            if self.last < workspace_num:
+                os.popen(f"wmctrl -s {index}")
 
     # Assigns functions to Wnck.Screen signals. Check out the API docs at
     # "http://lazka.github.io/pgi-docs/index.html#Wnck-3.0/classes/Screen.html"

--- a/dynamic_workspaces.py
+++ b/dynamic_workspaces.py
@@ -155,9 +155,8 @@ class DynamicWorkspaces:
             window.move_to_workspace(self.screen.get_workspaces()[window.get_workspace().get_number() - 1])
         self.pop_workspace(len(workspaces))
         # Make sure you stay on the workspace
-        if workspace_num != None:
-            if self.last < workspace_num:
-                os.popen(f"wmctrl -s {index}")
+        if workspace_num and self.last < workspace_num:
+            os.popen(f"wmctrl -s {index}")
 
     # Assigns functions to Wnck.Screen signals. Check out the API docs at
     # "http://lazka.github.io/pgi-docs/index.html#Wnck-3.0/classes/Screen.html"


### PR DESCRIPTION
When switching to the left from an empty workspace that has used workspaces to the left and right, the workspace would incorrectly switch to the right.
This caused the program to switch to the right instead of the left.

By keeping track of the last workspace, the program can check if the user switched to the right or left and then act accordingly.

I'm using this on Budgie, hence the name of my fork. I don't know if this is a problem on XFCE too, but it probably is (if Budgie and XFCE handle workspaces the same way, which they probably do).